### PR TITLE
Fixes

### DIFF
--- a/classes/class.ilAdobeConnectXMLAPI.php
+++ b/classes/class.ilAdobeConnectXMLAPI.php
@@ -32,7 +32,7 @@ class ilAdobeConnectXMLAPI
      */
     protected static $breeze_session = null;
     
-    protected string $auth_mode = '';
+    protected $auth_mode = '';
     /**
      * @var array
      */

--- a/classes/class.ilObjAdobeConnect.php
+++ b/classes/class.ilObjAdobeConnect.php
@@ -1531,7 +1531,7 @@ class ilObjAdobeConnect extends ilObjectPlugin
     {
         global $DIC;
         $ilDB = $DIC->database();
-
+        $local_scos = array();
         $res = $ilDB->query('SELECT sco_id FROM rep_robj_xavc_data');
         while ($row = $ilDB->fetchAssoc($res)) {
             $local_scos[] = $row['sco_id'];


### PR DESCRIPTION
This PR fixes following issues:
- PHP Parse error:  syntax error, unexpected 'string' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in ./classes/class.ilAdobeConnectXMLAPI.php on line 35
- "Return value of ilObjAdobeConnect::getLocalScos() must be of the type array, null returned" 

Thank you! 